### PR TITLE
Add library.properties metadata file

### DIFF
--- a/HIH6130/library.properties
+++ b/HIH6130/library.properties
@@ -1,0 +1,10 @@
+name=HIH6130
+version=0.0.1
+author=Michael de Silva
+maintainer=Michael de Silva
+sentence=Read the HIH6130 digital humidity/temperature sensor.
+paragraph=
+category=Sensors
+url=https://github.com/bsodmike/iot-arduino-libraries
+architectures=*
+includes=HIH6130.h


### PR DESCRIPTION
Libraries in the Arduino Library 1.5 format (source files under the src subfolder) are required to have a library.properties file in the root folder. If this file is not present the library is not recognized by the Arduino IDE.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#library-metadata